### PR TITLE
Taylor Keller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@
 /yarn-error.log
 
 .byebug_history
+
+# Ignore application configuration
+/config/application.yml

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -4,5 +4,4 @@ class SearchController < ApplicationController
     search_results = SearchResults.new
     @members = search_results.members(params[:nation])
   end
-
 end

--- a/app/controllers/search_controller.rb
+++ b/app/controllers/search_controller.rb
@@ -1,0 +1,8 @@
+class SearchController < ApplicationController
+
+  def index
+    search_results = SearchResults.new
+    @members = search_results.members(params[:nation])
+  end
+
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -1,0 +1,11 @@
+class Member
+  attr_reader :name, :photo, :allies, :enemies, :affiliation
+
+  def initialize(member_data)
+    @name = member_data[:name]
+    @photo = member_data[:photoUrl]
+    @allies = member_data[:allies]
+    @enemies = member_data[:enemies]
+    @affiliation = member_data[:affiliation]
+  end
+end

--- a/app/models/member.rb
+++ b/app/models/member.rb
@@ -4,8 +4,8 @@ class Member
   def initialize(member_data)
     @name = member_data[:name]
     @photo = member_data[:photoUrl]
-    @allies = member_data[:allies]
-    @enemies = member_data[:enemies]
+    @allies = member_data[:allies].join(', ')
+    @enemies = member_data[:enemies].join(', ')
     @affiliation = member_data[:affiliation]
   end
 end

--- a/app/poros/search_results.rb
+++ b/app/poros/search_results.rb
@@ -1,0 +1,21 @@
+class SearchResults
+
+  def initialize
+    @avatar_service ||= AvatarService.new
+  end
+
+  def members(nation)
+    nation = format_nation_input(nation)
+    json = @avatar_service.nation_members(nation)
+
+    json.map do |member_data|
+      Member.new(member_data)
+    end
+  end
+
+  private
+
+  def format_nation_input(nation)
+    nation.sub(/_/, '+')
+  end
+end

--- a/app/poros/search_results.rb
+++ b/app/poros/search_results.rb
@@ -16,6 +16,8 @@ class SearchResults
   private
 
   def format_nation_input(nation)
-    nation.sub(/_/, '+')
+    return nation.sub(/_/, '+') unless nation == 'water_tribes'
+
+    nation.sub(/_/, '+').delete('s')
   end
 end

--- a/app/services/avatar_service.rb
+++ b/app/services/avatar_service.rb
@@ -1,0 +1,17 @@
+class AvatarService
+
+  def nation_members(nation)
+    get_json("/api/v1/characters?affiliation=#{nation}")
+  end
+
+  private
+
+  def conn
+    conn ||= Faraday.new(url: 'https://last-airbender-api.herokuapp.com')
+  end
+
+  def get_json(url)
+    response = conn.get(url)
+    JSON.parse(response.body, symbolize_names: true)
+  end
+end

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,0 +1,12 @@
+<h1>Search Results</h1>
+
+<section id='results'>
+  <% @members.each do |member| %>
+    <ul class='member'>
+      <li class='name'><%= member.name %></li>
+      <li class='allies'>Allies: <%= member.allies %> </li>
+      <li class='enemies'>Enemies: <%= member.enemies %> </li>
+      <li class='affiliations'>Affiliations: <%= member.affiliation %> </li>
+    </ul>
+  <% end %>
+</section>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -3,6 +3,7 @@
 <section id='results'>
   <h3>Total Members: <%= @members.count %></h3>
   <% @members.each do |member| %>
+    <%= image_tag member.photo unless member.photo.nil? %>
     <ul class='member'>
       <li class='name'>Name: <%= member.name %></li>
       <li class='allies'>Allies: <%= member.allies %> </li>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -1,6 +1,7 @@
 <h1>Search Results</h1>
 
 <section id='results'>
+  <h3>Total Members: <%= @members.count %></h3>
   <% @members.each do |member| %>
     <ul class='member'>
       <li class='name'><%= member.name %></li>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -3,8 +3,8 @@
 <section id='results'>
   <h3>Total Members: <%= @members.count %></h3>
   <% @members.each do |member| %>
-    <%= image_tag member.photo unless member.photo.nil? %>
     <ul class='member'>
+      <%= image_tag(member.photo, class: 'photo') unless member.photo.nil? %>
       <li class='name'>Name: <%= member.name %></li>
       <li class='allies'>Allies: <%= member.allies %> </li>
       <li class='enemies'>Enemies: <%= member.enemies %> </li>

--- a/app/views/search/index.html.erb
+++ b/app/views/search/index.html.erb
@@ -4,7 +4,7 @@
   <h3>Total Members: <%= @members.count %></h3>
   <% @members.each do |member| %>
     <ul class='member'>
-      <li class='name'><%= member.name %></li>
+      <li class='name'>Name: <%= member.name %></li>
       <li class='allies'>Allies: <%= member.allies %> </li>
       <li class='enemies'>Enemies: <%= member.enemies %> </li>
       <li class='affiliations'>Affiliations: <%= member.affiliation %> </li>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,18 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 0) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+
+end

--- a/spec/features/visitor_can_search_for_fire_nation_members_spec.rb
+++ b/spec/features/visitor_can_search_for_fire_nation_members_spec.rb
@@ -9,6 +9,7 @@ describe 'As a visitor' do
       click_on 'Search For Members'
 
       expect(current_path). to eq('/search')
+      expect(page).to have_content('Total Members: 20')
       expect(page).to have_css('.member', count: 20)
     end
 

--- a/spec/features/visitor_can_search_for_fire_nation_members_spec.rb
+++ b/spec/features/visitor_can_search_for_fire_nation_members_spec.rb
@@ -22,6 +22,7 @@ describe 'As a visitor' do
       expect(current_path). to eq('/search')
 
       within(first('.member')) do
+        expect(page).to have_css('.photo')
         expect(page).to have_css('.name')
         expect(page).to have_css('.allies')
         expect(page).to have_css('.enemies')

--- a/spec/features/visitor_can_search_for_fire_nation_members_spec.rb
+++ b/spec/features/visitor_can_search_for_fire_nation_members_spec.rb
@@ -11,5 +11,21 @@ describe 'As a visitor' do
       expect(current_path). to eq('/search')
       expect(page).to have_css('.member', count: 20)
     end
+
+    it 'I see detailed information for each member' do
+      visit '/'
+
+      select 'Fire Nation', from: :nation
+      click_on 'Search For Members'
+
+      expect(current_path). to eq('/search')
+
+      within(first('.member')) do
+        expect(page).to have_css('.name')
+        expect(page).to have_css('.allies')
+        expect(page).to have_css('.enemies')
+        expect(page).to have_css('.affiliations')
+      end
+    end
   end
 end

--- a/spec/features/visitor_can_search_for_fire_nation_members_spec.rb
+++ b/spec/features/visitor_can_search_for_fire_nation_members_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'As a visitor' do
+  describe 'When I visit the welcome page' do
+    it 'I can search for fire nation members' do
+      visit '/'
+
+      select 'Fire Nation', from: :nation
+      click_on 'Search For Members'
+
+      expect(current_path). to eq('/search')
+      expect(page).to have_css('.member', count: 20)
+    end
+  end
+end

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+describe Member do
+  it 'can be created' do
+    member_data = {
+      name: 'Sakka',
+      photoUrl: 'Sakka.jpg',
+      allies: ['Aang', 'Katara'],
+      enemies: ['Zuko', 'Azula'],
+      affiliation: ['Team Avatar', 'Water Tribe Warriors']
+    }
+
+    member = Member.new(member_data)
+
+    expect(member).to be_a Member
+    expect(member.name).to eq(member_data[:name])
+    expect(member.photo).to eq(member_data[:photoUrl])
+    expect(member.allies).to eq(member_data[:allies].join(', '))
+    expect(member.enemies).to eq(member_data[:enemies].join(', '))
+    expect(member.affiliation).to eq(member_data[:affiliation])
+  end
+end

--- a/spec/poros/search_results_spec.rb
+++ b/spec/poros/search_results_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe SearchResults do
+  describe 'Instance methods' do
+    # it '#format_nation_input' do
+    #   search_results = SearchResults.new
+    #   fire_nation = 'fire_nation'
+    #   earth_kingdom = 'earth_kingdom'
+    #   air_nomads = 'air_nomads'
+    #   water_tribes = 'water_tribes'
+    #   formatted_fire_nation = search_results.format_nation_input(fire_nation)
+    #   formatted_earth_kingdom = search_results.format_nation_input(earth_kingdom)
+    #   formatted_air_nomads = search_results.format_nation_input(air_nomads)
+    #   formatted_water_tribes = search_results.format_nation_input(water_tribes)
+    #
+    #   expect(formatted_fire_nation).to eq('fire+nation')
+    #   expect(formatted_earth_kingdom).to eq('earth+kingdom')
+    #   expect(formatted_air_nomads).to eq('air+nomads')
+    #   expect(formatted_water_tribes).to eq('water+tribe')
+    # end
+
+    it '#members' do
+      search_results = SearchResults.new
+      members = search_results.members('fire_nation')
+
+      expect(members).to be_a Array
+      expect(members.first).to be_a Member
+    end
+  end
+end

--- a/spec/services/avatar_service_spec.rb
+++ b/spec/services/avatar_service_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe AvatarService do
+  describe 'Instance methods' do
+    it '#nation_members' do
+      service = AvatarService.new
+      nation_members = AvatarService.new.nation_members('Water+Tribe')
+      expect(nation_members).to be_a Array
+      member_data = nation_members.first
+
+      expect(member_data).to have_key :name
+      expect(member_data).to have_key :affiliation
+      expect(member_data).to have_key :enemies
+      expect(member_data).to have_key :allies
+      expect(member_data).to have_key :photoUrl
+    end
+  end
+end


### PR DESCRIPTION
- In my SearchResults poro I have a 'format_nation_input' method. In it I truncate the 's' from 'water+tribes' to correctly hit the API. A better solution could have been to change the 'element_nation' method in 'ApplicationHelper' to remove the 's' from 'water_tribes', but I didn't want to touch your code. 
- I have a test commented out in my SearchResults spec. The method I was testing is private, and I wasn't sure how to directly test it without making the method public. 